### PR TITLE
Fix null-reference errors on add pages

### DIFF
--- a/ReferralManagement/Pages/Patients/AddPatient.cshtml.cs
+++ b/ReferralManagement/Pages/Patients/AddPatient.cshtml.cs
@@ -8,11 +8,19 @@ namespace ReferralManagement.Pages.Patients
     public class AddPatientModel : PageModel
     {
         private IPatientService _patientService;
-        public Patient Patient { get; set; }
+        public Patient Patient { get; set; } = new Patient();
 
         public AddPatientModel(IPatientService patientService)
         {
             _patientService = patientService;
+        }
+
+        public IActionResult OnGet()
+        {
+            // Provide an empty patient so the razor page does not encounter
+            // null reference issues when binding form fields.
+            Patient = new Patient();
+            return Page();
         }
 
 

--- a/ReferralManagement/Pages/Referrals/AddReferral.cshtml.cs
+++ b/ReferralManagement/Pages/Referrals/AddReferral.cshtml.cs
@@ -9,11 +9,21 @@ namespace ReferralManagement.Pages
     {
         private IReferralService _referralService;
         // Add other properties for player stats as needed
-        public Referral Referral { get; set; }
+        public Referral Referral { get; set; } = new Referral();
 
         public AddReferralModel(IReferralService referralService)
         {
             _referralService = referralService;
+        }
+
+        public IActionResult OnGet()
+        {
+            // Initialize a new referral so the razor page has non-null values
+            Referral = new Referral
+            {
+                ReferralDate = DateTime.Today
+            };
+            return Page();
         }
 
         public async Task<IActionResult> OnPostAsync(Referral referral)


### PR DESCRIPTION
## Summary
- initialize `Referral` and `Patient` models when loading Add pages
- return the Razor page after preparing defaults

## Testing
- `dotnet build ReferralManagement.sln`

------
https://chatgpt.com/codex/tasks/task_e_683f8e2fcdb88324ac4c96fd6dd36285